### PR TITLE
Split reference choices by gencode version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.4.2] - 2025-09-16
+### Added
+- gencode parameter for handling different gencode/reference assembly combinations
 ### Changed
 - Gencode parameter will determine additional faceting of genomic resources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2025-09-16
+### Changed
+- Gencode parameter will determine additional faceting of genomic resources
+
 ## [2.4.1] - 2025-09-16
 ### Changed
 - [GRD-964](https://jira.oicr.on.ca/browse/GRD-964)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - gencode parameter for handling different gencode/reference assembly combinations
 ### Changed
 - Gencode parameter will determine additional faceting of genomic resources
+- Moved the output metadata into the main workflow code block
 
 ## [2.4.1] - 2025-09-16
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Parameter|Value|Description
 `inputGroups`|Array[InputGroup]|Array of fastq files to align with STAR and the merged filename
 `outputFileNamePrefix`|String|Prefix for filename
 `reference`|String|Reference id, hg19 or hg38
+`gencode`|String|Gencode version
 
 #### Optional task parameters:
 Parameter|Value|Default|Description

--- a/star.wdl
+++ b/star.wdl
@@ -19,6 +19,7 @@ workflow star {
     Array[InputGroup] inputGroups
     String outputFileNamePrefix
     String reference
+    String gencode
   }
 
   scatter (ig in inputGroups) {
@@ -27,15 +28,24 @@ workflow star {
     String readGroups = ig.readGroup
   }
 
-  Map[String,GenomeResources] resources = {
+  Map[String, Map[String,GenomeResources]] resources = {
     "hg38": {
-      "genomeIndexDir": "$HG38_STAR_INDEX100_ROOT/",
-      "modules": "hg38-star-index100/2.7.10b-gencode44",
-      "chimOutJunForm": 1
+      "31": {
+        "genomeIndexDir": "$HG38_STAR_INDEX100_ROOT/",
+        "modules": "hg38-star-index100/2.7.10b",
+        "chimOutJunForm": 1
+      },
+      "44": {
+        "genomeIndexDir": "$HG38_STAR_INDEX100_ROOT/",
+        "modules": "hg38-star-index100/2.7.10b-gencode44",
+        "chimOutJunForm": 1
+      }
     },
     "hg19": {
-      "genomeIndexDir": "$HG19_STAR_INDEX100_ROOT/",
-      "modules": "hg19-star-index100/2.7.10b"
+      "31": {
+        "genomeIndexDir": "$HG19_STAR_INDEX100_ROOT/",
+        "modules": "hg19-star-index100/2.7.10b"
+      }
     }
   }
 
@@ -44,6 +54,7 @@ workflow star {
     inputGroups: "Array of fastq files to align with STAR and the merged filename"
     outputFileNamePrefix: "Prefix for filename"
     reference: "Reference id, hg19 or hg38"
+    gencode: "Gencode version"
   }
 
   call runStar {
@@ -51,9 +62,9 @@ workflow star {
     read1s = read1s,
     read2s = read2s,
     readGroups = readGroups,
-    genomeIndexDir = resources [reference].genomeIndexDir,
-    modules = resources [reference].modules,
-    chimOutJunForm = resources [reference].chimOutJunForm,
+    genomeIndexDir = resources [reference][gencode].genomeIndexDir,
+    modules = resources [reference][gencode].modules,
+    chimOutJunForm = resources [reference][gencode].chimOutJunForm,
     outputFileNamePrefix = outputFileNamePrefix
   }
 

--- a/star.wdl
+++ b/star.wdl
@@ -86,6 +86,28 @@ workflow star {
         url: "https://broadinstitute.github.io/picard/"
       }
     ]
+    output_meta: {
+      starBam: {
+        description: "Output bam aligned to genome",
+        vidarr_label: "starBam"
+      },
+      starIndex: {
+        description: "Output bam index",
+        vidarr_label: "starIndex"
+      },
+      starChimeric: {
+        description: "Output chimeric junctions file",
+        vidarr_label: "starChimeric"
+      },
+      transcriptomeBam: {
+        description: "Output bam aligned to transcriptome",
+        vidarr_label: "transcriptomeBam"
+      },
+      geneReadFile: {
+        description: "Output raw read counts per transcript",
+        vidarr_label: "geneReadFile"
+      }
+    }
 }
 
 output {
@@ -230,27 +252,6 @@ output {
  File geneReads        = "~{outputFileNamePrefix}.~{genereadSuffix}.tab"
 }
 
-meta {
-    output_meta: {
-    outputBam: {
-        description: "Output bam aligned to genome",
-        vidarr_label: "outputBam"
-    },
-    outputChimeric: {
-        description: "Output chimeric junctions file",
-        vidarr_label: "outputChimeric"
-    },
-    transcriptomeBam: {
-        description: "Output bam aligned to transcriptome",
-        vidarr_label: "transcriptomeBam"
-    },
-    geneReads: {
-        description: "Output raw read counts per transcript",
-        vidarr_label: "geneReads"
-    }
-}
-}
-
 }
 
 # ==========================================
@@ -279,19 +280,13 @@ command <<<
 >>>
 
 runtime {
-   memory: "~{jobMemory} GB"
+  memory: "~{jobMemory} GB"
   modules: "~{modules}"
   timeout: "~{timeout}"
 }
 
 output {
   File outputBai = "~{basename(inputBam, '.bam')}.bai"
-}
-
-meta {
-  output_meta: {
-    outputBai: "Output index file for bam aligned to genome"
-  }
 }
 
 }

--- a/star.wdl
+++ b/star.wdl
@@ -29,6 +29,12 @@ workflow star {
   }
 
   Map[String, Map[String,GenomeResources]] resources = {
+    "hg19": {
+      "31": {
+        "genomeIndexDir": "$HG19_STAR_INDEX100_ROOT/",
+        "modules": "hg19-star-index100/2.7.10b"
+      }
+    },
     "hg38": {
       "31": {
         "genomeIndexDir": "$HG38_STAR_INDEX100_ROOT/",
@@ -41,10 +47,18 @@ workflow star {
         "chimOutJunForm": 1
       }
     },
-    "hg19": {
-      "31": {
-        "genomeIndexDir": "$HG19_STAR_INDEX100_ROOT/",
-        "modules": "hg19-star-index100/2.7.10b"
+    "hg38_noAlt": {
+      "44": {
+        "genomeIndexDir": "$HG38_NOALT_STAR_INDEX100_ROOT/",
+        "modules": "hg38-noalt-star-index100/2.7.10b-gencode44",
+        "chimOutJunForm": 1
+      }
+    },
+    "grch38": {
+      "44": {
+        "genomeIndexDir": "$HG38_NCBI_STAR_INDEX100_ROOT/",
+        "modules": "hg38-ncbi-star-index100/2.7.10b-gencode44",
+        "chimOutJunForm": 1
       }
     }
   }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -5,6 +5,7 @@
             "star.indexBam.modules": null,
             "star.indexBam.timeout": null,
             "star.reference": "hg38",
+            "star.gencode": "44",
             "star.inputGroups": [
                 {
                     "fastqR1": {
@@ -153,6 +154,7 @@
             "star.indexBam.modules": null,
             "star.indexBam.timeout": null,
             "star.reference": "hg19",
+            "star.gencode": "31",
             "star.inputGroups": [
                 {
                     "fastqR1": {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -5,7 +5,7 @@
             "star.indexBam.modules": null,
             "star.indexBam.timeout": null,
             "star.reference": "hg38",
-            "star.gencode": "44",
+            "star.gencode": "31",
             "star.inputGroups": [
                 {
                     "fastqR1": {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -62,7 +62,7 @@
                     "readGroup": "ID:Test_NoIndex PL:Illumina PU:Test_NoIndex LB:K_1 SM:K_1test CN:OICR"
                 }
             ],
-            "star.outputFileNamePrefix": "K562",
+            "star.outputFileNamePrefix": "K",
             "star.runStar.addParam": null,
             "star.runStar.alignIntMax": null,
             "star.runStar.alignMatGapMax": null,
@@ -143,7 +143,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/STAR/2.3/output_metrics/workflow_test_01.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/STAR/output_metrics/workflow_test_01.metrics",
                 "type": "script"
             }
         ]
@@ -292,7 +292,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/STAR/2.3/output_metrics/workflow_test_01.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/STAR/output_metrics/workflow_test_01a.metrics",
                 "type": "script"
             }
         ]

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -1,5 +1,5 @@
 [
-    {
+    { 
         "arguments": {
             "star.indexBam.jobMemory": null,
             "star.indexBam.modules": null,
@@ -91,17 +91,17 @@
             "star.runStar.transcriptomeSuffix": null,
             "star.runStar.uniqMAPQ": null
         },
-        "description": "STAR workflow test",
+        "description": "STAR workflow test with hg38 and gencode v31",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false
         },
-        "id": "k562_RNAseqTest",
+        "id": "k562_RNAseqTest31",
         "metadata": {
             "star.geneReadFile": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -109,7 +109,7 @@
             "star.starBam": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -117,7 +117,7 @@
             "star.starChimeric": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -125,7 +125,7 @@
             "star.starIndex": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest31_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -133,7 +133,156 @@
             "star.transcriptomeBam": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest31_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            }
+        },
+        "validators": [
+            {
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
+                "output_metrics": "/.mounts/labs/gsi/testdata/STAR/2.3/output_metrics/workflow_test_01.metrics",
+                "type": "script"
+            }
+        ]
+    },
+    {
+        "arguments": {
+            "star.indexBam.jobMemory": null,
+            "star.indexBam.modules": null,
+            "star.indexBam.timeout": null,
+            "star.reference": "hg38",
+            "star.gencode": "44",
+            "star.inputGroups": [
+                {
+                    "fastqR1": {
+                        "contents": {
+                            "configuration": "/.mounts/labs/gsi/testdata/STAR/test_inputs/kTest_R1.fastq.gz",
+                            "externalIds": [
+                                {
+                                    "id": "TEST",
+                                    "provider": "TEST"
+                                }
+                            ]
+                        },
+                        "type": "EXTERNAL"
+                    },
+                    "fastqR2": {
+                        "contents": {
+                            "configuration": "/.mounts/labs/gsi/testdata/STAR/test_inputs/kTest_R2.fastq.gz",
+                            "externalIds": [
+                                {
+                                    "id": "TEST",
+                                    "provider": "TEST"
+                                }
+                            ]
+                        },
+                        "type": "EXTERNAL"
+                    },
+                    "readGroup": "ID:Test_NoIndex PL:Illumina PU:Test_NoIndex LB:K_1 SM:K_1test CN:OICR"
+                },
+                {
+                    "fastqR1": {
+                        "contents": {
+                            "configuration": "/.mounts/labs/gsi/testdata/STAR/test_inputs/kTest_R1.fastq.gz",
+                            "externalIds": [
+                                {
+                                    "id": "TEST",
+                                    "provider": "TEST"
+                                }
+                            ]
+                        },
+                        "type": "EXTERNAL"
+                    },
+                    "fastqR2": {
+                        "contents": {
+                            "configuration": "/.mounts/labs/gsi/testdata/STAR/test_inputs/kTest_R2.fastq.gz",
+                            "externalIds": [
+                                {
+                                    "id": "TEST",
+                                    "provider": "TEST"
+                                }
+                            ]
+                        },
+                        "type": "EXTERNAL"
+                    },
+                    "readGroup": "ID:Test_NoIndex PL:Illumina PU:Test_NoIndex LB:K_1 SM:K_1test CN:OICR"
+                }
+            ],
+            "star.outputFileNamePrefix": "K562",
+            "star.runStar.addParam": null,
+            "star.runStar.alignIntMax": null,
+            "star.runStar.alignMatGapMax": null,
+            "star.runStar.alignSJDBOvMin": null,
+            "star.runStar.chimJunOvMin": null,
+            "star.runStar.chimMulmapNmax": null,
+            "star.runStar.chimMulmapScoRan": null,
+            "star.runStar.chimNonchimScoDMin": null,
+            "star.runStar.chimOutType": null,
+            "star.runStar.chimScoJunNonGTAG": null,
+            "star.runStar.chimScoreDropMax": null,
+            "star.runStar.chimScoreSeparation": null,
+            "star.runStar.chimSegmentReadGapMax": null,
+            "star.runStar.chimSegmin": null,
+            "star.runStar.chimericjunctionSuffix": null,
+            "star.runStar.genereadSuffix": null,
+            "star.runStar.jobMemory": null,
+            "star.runStar.multiMax": null,
+            "star.runStar.outFilterMultimapNmax": null,
+            "star.runStar.peOvMMp": null,
+            "star.runStar.peOvNbasesMin": null,
+            "star.runStar.saSparsed": null,
+            "star.runStar.starSuffix": null,
+            "star.runStar.threads": null,
+            "star.runStar.timeout": null,
+            "star.runStar.transcriptomeSuffix": null,
+            "star.runStar.uniqMAPQ": null
+        },
+        "description": "STAR workflow test with hg38 and gencode v44",
+        "engineArguments": {
+           "write_to_cache": false,
+           "read_from_cache": false
+        },
+        "id": "k562_RNAseqTest44",
+        "metadata": {
+            "star.geneReadFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest44_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "star.starBam": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest44_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "star.starChimeric": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest44_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "star.starIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest44_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "star.transcriptomeBam": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_STAR_k562_RNAseqTest44_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -240,7 +389,7 @@
             "star.runStar.transcriptomeSuffix": null,
             "star.runStar.uniqMAPQ": null
         },
-        "description": "STAR workflow test",
+        "description": "STAR workflow test with hg19 and gencode v31",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false


### PR DESCRIPTION
This PR is to address an issue with multiple **gencode/hg** assembly combinations and includes the following changes:

- added gencode parameter (simply a gencode version, 31 44 etc)
- genomic resources are more deeply nested and allow different gencode/reference combinations